### PR TITLE
Added new tabs for combined sections, section note, and split time in…

### DIFF
--- a/api/prisma/migrations/20230414145403_add_new_section_columns/migration.sql
+++ b/api/prisma/migrations/20230414145403_add_new_section_columns/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `time` on the `sections` table. All the data in the column will be lost.
+  - Added the required column `combined_days` to the `sections` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `combined_location` to the `sections` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `combined_time_start` to the `sections` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `combined_time_stop` to the `sections` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `is_combined` to the `sections` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `note` to the `sections` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `timeStart` to the `sections` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `timeStop` to the `sections` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "sections" DROP COLUMN "time",
+ADD COLUMN     "combined_days" TEXT NOT NULL,
+ADD COLUMN     "combined_location" TEXT NOT NULL,
+ADD COLUMN     "combined_time_start" TEXT NOT NULL,
+ADD COLUMN     "combined_time_stop" TEXT NOT NULL,
+ADD COLUMN     "is_combined" BOOLEAN NOT NULL,
+ADD COLUMN     "note" TEXT NOT NULL,
+ADD COLUMN     "timeStart" TEXT NOT NULL,
+ADD COLUMN     "timeStop" TEXT NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,85 +1,91 @@
-
 generator client {
-  provider = "prisma-client-js"
+    provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
 }
 
 model User {
-  id            String   @id @default(uuid())
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
-  email         String   @unique
-  hash          String
-  firstName     String   @map("first_name")
-  lastName      String   @map("last_name")
-  emailVerified Boolean  @map("email_verified")
+    id            String   @id @default(uuid())
+    createdAt     DateTime @default(now()) @map("created_at")
+    updatedAt     DateTime @updatedAt @map("updated_at")
+    email         String   @unique
+    hash          String
+    firstName     String   @map("first_name")
+    lastName      String   @map("last_name")
+    emailVerified Boolean  @map("email_verified")
 
-  @@map("users")
+    @@map("users")
 }
 
 model Schedule {
-  id        String   @id @default(uuid())
-  userId    String   @map("user_id")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
-  quarterId Int      @map("quarter_id")
-  data      Json
+    id        String   @id @default(uuid())
+    userId    String   @map("user_id")
+    createdAt DateTime @default(now()) @map("created_at")
+    updatedAt DateTime @updatedAt @map("updated_at")
+    quarterId Int      @map("quarter_id")
+    data      Json
 
-  @@map("schedules")
+    @@map("schedules")
 }
 
 model Quarter {
-  id          Int       @id @default(autoincrement())
-  year        Int       @db.SmallInt
-  season      String
-  dateUpdated DateTime  @map("date_updated") @db.Timestamptz()
-  // not a literal column in DB. Just describes relationship
-  Subject     Subject[]
+    id          Int       @id @default(autoincrement())
+    year        Int       @db.SmallInt
+    season      String
+    dateUpdated DateTime  @map("date_updated") @db.Timestamptz()
+    // not a literal column in DB. Just describes relationship
+    Subject     Subject[]
 
-  @@map("quarters")
+    @@map("quarters")
 }
 
 model Subject {
-  subjectId String   @id @default(uuid()) @map("subject_id")
-  name      String   @unique
-  quarterId Int      @map("quarter_id")
-  // not literal columns in DB. Just describes relationship
-  quarters  Quarter  @relation(fields: [quarterId], references: [id], onDelete: Cascade)
-  courses   Course[]
+    subjectId String   @id @default(uuid()) @map("subject_id")
+    name      String   @unique
+    quarterId Int      @map("quarter_id")
+    // not literal columns in DB. Just describes relationship
+    quarters  Quarter  @relation(fields: [quarterId], references: [id], onDelete: Cascade)
+    courses   Course[]
 
-  @@map("subjects")
+    @@map("subjects")
 }
 
 model Course {
-  courseId  String    @id @default(uuid()) @map("course_id")
-  name      String
-  subjectId String    @map("subject_id")
-  // not literal columns in DB. Just describes relationship
-  subjects  Subject   @relation(fields: [subjectId], references: [subjectId], onDelete: Cascade)
-  sections  Section[]
+    courseId  String    @id @default(uuid()) @map("course_id")
+    name      String
+    subjectId String    @map("subject_id")
+    // not literal columns in DB. Just describes relationship
+    subjects  Subject   @relation(fields: [subjectId], references: [subjectId], onDelete: Cascade)
+    sections  Section[]
 
-  @@map("courses")
+    @@map("courses")
 }
 
 model Section {
-  sectionId    String @id @default(uuid()) @map("section_id")
-  courseId     String @map("course_id")
-  callNumber   Int    @map("call_number")
-  sectionTitle String @map("section_title")
-  creditHours  Int    @map("credit_hours") @db.SmallInt
-  activity     String
-  modality     String
-  days         String
-  time         String
-  location     String
-  instructor   String
-  status       String
-  // not a literal column in DB. Just describes relationship
-  courses      Course @relation(fields: [courseId], references: [courseId], onDelete: Cascade)
+    sectionId         String  @id @default(uuid()) @map("section_id")
+    courseId          String  @map("course_id")
+    callNumber        Int     @map("call_number")
+    sectionTitle      String  @map("section_title")
+    creditHours       Int     @map("credit_hours") @db.SmallInt
+    activity          String
+    modality          String
+    days              String
+    timeStart         String
+    timeStop          String
+    location          String
+    instructor        String
+    status            String
+    isCombined        Boolean @map("is_combined")
+    combinedDays      String  @map("combined_days")
+    combinedTimeStart String  @map("combined_time_start")
+    combinedTimeStop  String  @map("combined_time_stop")
+    combinedLocation  String  @map("combined_location")
+    note              String
+    // not a literal column in DB. Just describes relationship
+    courses           Course  @relation(fields: [courseId], references: [courseId], onDelete: Cascade)
 
-  @@map("sections")
+    @@map("sections")
 }


### PR DESCRIPTION
# Column Changes

- Added combined section columns
  - is_combined
  - combined_start
  - combined_stop
  - combined_location
  - combined_days
- split "time" column
  - time_start
  - time_stop
- Added "note" column

# Reasoning

To support the combined sections, we need to add some new columns to support that data.

I split time into two columns to be more in line with how we represent that data on the front end and to be more consistent with how we're representing it in the web scraper.

I added the *note* column because the notes about the prerequisites and extra fees are very important.